### PR TITLE
Run sitemap refresh task on restart.

### DIFF
--- a/recipes/_application.rb
+++ b/recipes/_application.rb
@@ -61,6 +61,12 @@ deploy_revision node['supermarket']['home'] do
       cwd release_path
       command 'bundle exec rake assets:precompile'
     end
+
+    execute 'sitemap:refresh' do
+      environment 'RAILS_ENV' => 'production'
+      cwd release_path
+      command 'bundle exec rake sitemap:refresh'
+    end
   end
 
   notifies :restart, 'service[unicorn]'


### PR DESCRIPTION
:fork_and_knife: 

As part of [adding sitemap support to Supermarket](https://github.com/opscode/supermarket/pull/394), I thought it would make sense to run the sitemap refresh command after restart.

I am not 100% sure if this is the correct way to handle this, so I am just throwing this out there. It is worth noting that the Supermarket PR is using [the sitemap_generator gem](https://github.com/kjvarga/sitemap_generator) to accomplish this.
