### PR TITLE
add rake db:seed to deploy resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,9 +10,15 @@ provisioner:
 platforms:
   - name: ubuntu-12.04
   - name: ubuntu-14.04
+    attributes:
+      postgres:
+        version: "9.3"
 
 suites:
   - name: default
     data_bags_path: data_bags
     run_list:
       - recipe[supermarket::default]
+    attributes:
+      postgres:
+        auth_method: trust

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@
 default['postgres']['user'] = 'supermarket'
 default['postgres']['database'] = 'supermarket_production'
 default['postgres']['auth_method'] = 'peer'
+default['postgres']['version'] = '9.1'
 
 default['redis']['maxmemory'] = '64mb'
 

--- a/data_bags/apps/supermarket.json
+++ b/data_bags/apps/supermarket.json
@@ -6,6 +6,9 @@
   "sentry_url": "someSentryUrl",
   "redis_url": "redis://127.0.0.1:6379",
   "database": {
+    "host": "localhost",
+    "username": "supermarket",
+    "password": "ExampleOnlyDontUseInProd"
   },
   "smtp": {
     "address": "someaddress.com",

--- a/recipes/_application.rb
+++ b/recipes/_application.rb
@@ -64,6 +64,14 @@ deploy_revision node['supermarket']['home'] do
     end
   end
 
+  after_restart do
+    execute 'db:seed' do
+      environment 'RAILS_ENV' => 'production'
+      cwd release_path
+      command 'bundle exec rake db:seed'
+    end
+  end
+
   notifies :restart, 'service[unicorn]'
   notifies :restart, 'service[sidekiq]'
 end

--- a/recipes/_postgres.rb
+++ b/recipes/_postgres.rb
@@ -51,11 +51,11 @@ execute 'postgres[extensions][pg_trgm]' do
   not_if "echo '\dx' | psql #{node['postgres']['database']} | grep pg_trgm"
 end
 
-directory '/etc/postgresql/9.1/main' do
+directory "/etc/postgresql/#{node['postgres']['version']}/main" do
   recursive true
 end
 
-template '/etc/postgresql/9.1/main/pg_hba.conf' do
+template "/etc/postgresql/#{node['postgres']['version']}/main/pg_hba.conf" do
   notifies :restart, 'service[postgresql]', :immediately
 end
 

--- a/test/integration/default/serverspec/app_spec.rb
+++ b/test/integration/default/serverspec/app_spec.rb
@@ -9,4 +9,19 @@ describe 'supermarket' do
     cmd = command 'wget -O - http://localhost 2> /dev/null'
     expect(cmd.stdout).to match '<!DOCTYPE html>'
   end
+
+  it 'has > 0 ICLAs' do
+    cmd = command %Q{echo 'SELECT count("iclas".*) FROM "iclas";' | sudo -u postgres psql supermarket_production | grep '^(. row.*)'}
+    cmd.stdout.match(/\((\d).*/)
+    res = $1.to_i
+    expect(res).to be > 0
+  end
+
+  it 'has > 0 CCLAs' do
+    cmd = command %Q{echo 'SELECT count("cclas".*) FROM "cclas";' | sudo -u postgres psql supermarket_production | grep '^(. row.*)'}
+    cmd.stdout.match(/\((\d).*/)
+    res = $1.to_i
+    expect(res).to be > 0
+  end
+
 end


### PR DESCRIPTION
This adds the rake db:seed command to the deploy resource to ensure
the database gets populated with the ICLA/CCLA. This is done during
the deployment after restart, as the database will be set up, and we
want to ensure that this happens. The rake task itself is idempotent,
so re-running it should have no side effects on the database.

This also ensures the proper version of postgresql is used based on
the platform. Due to path locations, the `db:migrate` and `db:seed`
commands were failing at different points. This adds an attribute for
the postgres version. By default it will be 9.1, and can be changed by
the end user if necessary.
