### PR TITLE
Support SSL redirect

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,3 +31,14 @@ default['supermarket']['host'] = 'supermarket.getchef.com'
 default['supermarket']['sidekiq']['concurrency'] = '25'
 default['supermarket']['database']['pool'] = 25
 default['supermarket']['data_bag'] = 'supermarket'
+
+# To use AWS ELB in front of Supermarket, set force_ssl to true, but
+# don't set the ssl_crt_path or ssl_key_path. To use SSL directly on
+# the nginx proxy in front of the app, set force_ssl to true and set
+# the path attributes below.
+default['supermarket']['force_ssl']  = false
+# To use custom SSL certificate/key, name the files, and in a separate
+# cookbook, manage them with your favorite method (chef-vault items,
+# regular data bags, etc).
+default['supermarket']['ssl_crt_path'] = nil
+default['supermarket']['ssl_key_path'] = nil

--- a/templates/default/supermarket.nginx.erb
+++ b/templates/default/supermarket.nginx.erb
@@ -4,6 +4,35 @@ upstream unicorn {
 
 server {
   listen 80;
+  server_name <%= node['supermarket']['host'] %>;
+<% if node['supermarket']['enforce_ssl'] -%>
+  proxy_set_header        Host            $host;
+  proxy_set_header        X-Real-IP       $remote_addr;
+  proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header        X-Forwarded-Proto https;
+  proxy_pass_request_headers on;
+  proxy_connect_timeout   90;
+  proxy_send_timeout      90;
+  proxy_read_timeout      90;
+  location / {
+    if ($http_x_forwarded_proto != 'https') {
+      return 301 https://$server_name$request_uri;
+    }
+  }
+}
+
+server {
+  listen 443;
+<%   if node['supermarket']['ssl_crt_name'] && node['supermarket']['ssl_key_name'] -%>
+  ssl_certificate <%= node['supermarket']['ssl_crt_name'] %>
+  ssl_certificate_key <%= node['supermarket']['ssl_key_name'] %>
+  ssl_ciphers                   HIGH:!kEDH:!ADH:!MD5;
+  ssl_prefer_server_ciphers     on;
+  ssl_protocols                 SSLv3 TLSv1;
+  ssl_session_cache             shared:SSL:4m;
+  ssl_session_timeout           5m;
+<%   end -%>
+<% end -%>
 
   location ~ /sitemap\d*.xml.gz {
     root <%= node['supermarket']['home'] %>/current/public;


### PR DESCRIPTION
If enforce_ssl attribute is true, then the nginx proxy will redirect
HTTP to HTTPS. By default there are no SSL configuration options set
with this as we're using AWS ELB to terminate HTTPS. Adding the ssl
certificate and key, plus additional options was added to lay the
groundwork for potential expansion on this, but it needs to be tested
(which includes building a self-signed certificate for the repository
to do the testing).

Background on this configuration method:

http://frankmitchell.org/2013/05/https-elb/
