### PR TITLE
Add Library Dependency for installing mysql2 gem

### DIFF
--- a/recipes/_application.rb
+++ b/recipes/_application.rb
@@ -18,8 +18,8 @@
 #
 
 include_recipe 'supermarket::_apt'
-include_recipe 'supermarket::_ruby'
 include_recipe 'supermarket::_mysql'
+include_recipe 'supermarket::_ruby'
 
 app = data_bag_item(:apps, node['supermarket']['data_bag'])
 


### PR DESCRIPTION
When deploying [Supermarket app](https://github.com/opscode/supermarket), chef cookbook
fails provisioning due to mysql2 gem not being able to be installed. Mysql2 gem depends on
libmysqlclient-dev and also on libmysql-ruby.

[This StackOverflow](http://stackoverflow.com/questions/3608287/error-installing-mysql2-failed-to-build-gem-native-extension) post shows the dependency.

Signed-off-by: "Jake Champlin" jake.champlin.27@gmail.com
