### PR TITLE
Package libarchive-dev

### DIFF
--- a/recipes/_ruby.rb
+++ b/recipes/_ruby.rb
@@ -55,4 +55,6 @@ package 'libsqlite3-dev'
 # when postgresql isn't running on the same node.
 package 'libpq-dev'
 
+package 'libarchive-dev'
+
 gem_package 'bundler'


### PR DESCRIPTION
:fork_and_knife: 

This is required for opscode/supermarket#485. I'm able to `kitchen converge` to deploy that branch to local VMs, but am unable to run `kitchen verify` due to this error:

```
-----> Running serverspec test suite       
/opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- rspec/core/rake_task (LoadErro
r)       
        from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'       
        from /tmp/busser/gems/gems/busser-serverspec-0.2.6/lib/busser/runner_plugin/../serverspec/runner.rb:21:in `<main>'       
Ruby Script [/tmp/busser/gems/gems/busser-serverspec-0.2.6/lib/busser/runner_plugin/../serverspec/runner.rb /tmp/busser/suites/serverspec] exit
 code was 1       
```

Does this ring any bells? I'd feel better about this PR if I could run the serverspecs and see them pass.
