### PR TITLE
Add gemrc for supermarket user

### DIFF
--- a/recipes/_users.rb
+++ b/recipes/_users.rb
@@ -28,3 +28,7 @@ user 'supermarket' do
   comment 'Supermarket'
   shell '/bin/false'
 end
+
+file ::File.join(node['supermarket']['home'], '.gemrc') do
+  content 'gem: --no-ri --no-rdoc'
+end


### PR DESCRIPTION
The supermarket bundle install takes a very long time, partially due to
building ri and rdoc for every gem installed.
