### PR TITLE
Remove libarchive-dev

### DIFF
--- a/recipes/_ruby.rb
+++ b/recipes/_ruby.rb
@@ -55,6 +55,4 @@ package 'libsqlite3-dev'
 # when postgresql isn't running on the same node.
 package 'libpq-dev'
 
-package 'libarchive-dev'
-
 gem_package 'bundler'


### PR DESCRIPTION
:fork_and_knife: 

This isn't needed any more now that the data import from the old community site is done.

Related to:
https://github.com/opscode/supermarket/pull/530
https://trello.com/c/zT2ZimzV/228-only-accept-gzipped-tarballs-as-uploads-via-the-api
