### PR TITLE
Add CCLA and ICLA versions to the .env.production template

### DIFF
--- a/templates/default/.env.production.erb
+++ b/templates/default/.env.production.erb
@@ -46,3 +46,5 @@ REDIS_URL=<%= @app['redis_url'] %>
 <% if @app['segment_io_write_key'] %>
 SEGMENT_IO_WRITE_KEY=<%= @app['segment_io_write_key'] %>
 <% end %>
+CCLA_VERSION=99999-2621/LEGAL14767024.1
+ICLA_VERSION=99999-2621/LEGAL14767024.1


### PR DESCRIPTION
:fork_and_knife: 

Now that `.env` is linked to the `.env.production` template, we need to specify ICLA/CCLA versions in the template.
