### PR TITLE
Revert "remove libarchive-dev"

### DIFF
--- a/recipes/_ruby.rb
+++ b/recipes/_ruby.rb
@@ -55,4 +55,6 @@ package 'libsqlite3-dev'
 # when postgresql isn't running on the same node.
 package 'libpq-dev'
 
+package 'libarchive-dev'
+
 gem_package 'bundler'


### PR DESCRIPTION
This reverts commit 2850866a493d0742f9f1a960f616d20ebb84a456.

opscode/supermarket#579 is going to require re-processing all of the old archives
