### PR TITLE
Adds nginx caching

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,9 @@ default['supermarket']['data_bag'] = 'supermarket'
 # `cookbooks.opscode.com` and `api.berkshelf.com`, this must be set as
 # an Array of domains that shouldn't be redirected to HTTPS by nginx.
 default['supermarket']['allow_http_domains'] = nil
+# Used to enable caching for berkshelf traffic via nginx. THIS WILL
+# BREAK COOKBOOK DOWNLOAD COUNTERS
+default['supermarket']['nginx']['cache'] = false
 # make a knob for the number of workers for unicorn.
 default['supermarket']['web_concurrency'] = node['cpu']['total']
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'supermarket'
-version '2.4.3'
+version '2.4.4'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@getchef.com'
 license 'Apache v2.0'

--- a/templates/default/supermarket.nginx.erb
+++ b/templates/default/supermarket.nginx.erb
@@ -4,6 +4,13 @@ upstream unicorn {
   server unix:/tmp/.supermarket.sock.0;
 }
 
+<% if node['supermarket']['nginx']['cache'] -%>
+proxy_cache_path /var/cache/supermarket levels=1:2 keys_zone=supermarket-cache:512m max_size=1000m inactive=600m;
+proxy_temp_path  /var/cache/tmp;
+
+log_format cache '$remote_addr - [$time_local] "$request" $upstream_cache_status $upstream_response_time $upstream_status';
+<% end %>
+
 server {
   listen 80 default_server;
   server_name <%= node['supermarket']['host'] %>;
@@ -93,6 +100,31 @@ server {
     add_header ETag "";
     break;
   }
+
+<% if node['supermarket']['nginx']['cache'] -%>
+  location ~ ^/api/v1/cookbooks/.*/versions/.*(/download)?$ {
+    proxy_set_header HOST $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_pass http://unicorn;
+    proxy_redirect off;
+
+    proxy_ignore_headers Set-Cookie Cache-Control;
+    proxy_buffering	on;
+
+    proxy_cache 	supermarket-cache;
+    proxy_cache_valid 	200 302 240m;
+    proxy_cache_valid 	any     5m;
+    expires		240m;
+
+    # to serve gzipped text and json responses
+    gzip on;
+    gzip_min_length 1000;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain application/json;
+  }
+<% end -%>
 
   location / {
     proxy_set_header HOST $host;


### PR DESCRIPTION
This is for high volume Berkshelf installations.  It caches the commonly used berkshelf api endpoints in nginx to avoid spinning up excessive unicorn workers.
