### PR TITLE
Support ENV based app feature flags

### DIFF
--- a/data_bags/apps/supermarket.json
+++ b/data_bags/apps/supermarket.json
@@ -23,5 +23,8 @@
     "github_access_token": "someAccessToken",
     "cla_location": "claUrl",
     "pubsubhubbub_secret": "someSecret"
-  }
+  },
+  "feature_flags": [
+    "tools_enabled"
+  ]
 }

--- a/data_bags/apps/supermarket_prod.json
+++ b/data_bags/apps/supermarket_prod.json
@@ -25,5 +25,8 @@
     "github_access_token": "someAccessToken",
     "cla_location": "claUrl",
     "pubsubhubbub_secret": "someSecret"
-  }
+  },
+  "feature_flags": [
+    "tools_enabled"
+  ]
 }

--- a/templates/default/.env.production.erb
+++ b/templates/default/.env.production.erb
@@ -49,3 +49,8 @@ GOOGLE_ANALYTICS_ID=<%= @app['google_analytics_id'] %>
 <% end %>
 CCLA_VERSION=99999-2621/LEGAL14767024.1
 ICLA_VERSION=99999-2621/LEGAL14767024.1
+<% if @app['feature_flags'] %>
+<% @app['feature_flags'].each do |feature_flag| %>
+<%= feature_flag.upcase %>=true
+<% end %>
+<% end %>

--- a/test/integration/default/serverspec/app_spec.rb
+++ b/test/integration/default/serverspec/app_spec.rb
@@ -27,4 +27,9 @@ describe 'supermarket' do
   describe file('/srv/supermarket/current/.env') do
     it { should be_linked_to '/srv/supermarket/shared/.env.production' }
   end
+
+  it 'writes feature flags to .env.production from the apps databag' do
+    cmd = command 'cat /srv/supermarket/shared/.env.production'
+    expect(cmd.stdout).to match 'TOOLS_ENABLED=true'
+  end
 end


### PR DESCRIPTION
:fork_and_knife: Since Supermarket is now in production it's useful to be able to enable or disable features as they're in active development. This allows you to specify an array of feature flags in the apps databag if a feature flag is present in the array then it gets enabled.
