### PR TITLE
configurable oauth2 site url

### DIFF
--- a/data_bags/apps/supermarket.json
+++ b/data_bags/apps/supermarket.json
@@ -17,7 +17,8 @@
   },
   "chef_oauth2": {
     "app_id": "someAppID",
-    "secret": "someSecret"
+    "secret": "someSecret",
+    "url": "https://id.opscode.com"
   },
   "curry": {
     "github_access_token": "someAccessToken",

--- a/templates/default/.env.production.erb
+++ b/templates/default/.env.production.erb
@@ -16,6 +16,9 @@ GITHUB_SECRET=<%= @app['github']['secret'] %>
 <% if @app['chef_oauth2'] %>
 CHEF_OAUTH2_APP_ID=<%= @app['chef_oauth2']['app_id'] %>
 CHEF_OAUTH2_SECRET=<%= @app['chef_oauth2']['secret'] %>
+<% if @app['chef_oauth2']['url'] %>
+CHEF_OAUTH2_URL=<%= @app['chef_oauth2']['url'] %>
+<% end %>
 <% end %>
 <% if @app['curry'] %>
 GITHUB_ACCESS_TOKEN=<%= @app['curry']['github_access_token'] %>


### PR DESCRIPTION
Allow setting the OAUTH2 url using the data bag e.g. for development and in-house deployments where oc-id is not available.

related: https://github.com/opscode/supermarket/pull/663
