### PR TITLE
Combine ENV feature flag variables into a single ENV variable

### DIFF
--- a/data_bags/apps/supermarket.json
+++ b/data_bags/apps/supermarket.json
@@ -26,7 +26,8 @@
     "cla_location": "claUrl",
     "pubsubhubbub_secret": "someSecret"
   },
-  "feature_flags": [
-    "tools_enabled"
+  "features": [
+    "tools",
+    "join_ccla"
   ]
 }

--- a/data_bags/apps/supermarket_prod.json
+++ b/data_bags/apps/supermarket_prod.json
@@ -27,7 +27,8 @@
     "cla_location": "claUrl",
     "pubsubhubbub_secret": "someSecret"
   },
-  "feature_flags": [
-    "tools_enabled"
+  "features": [
+    "tools",
+    "join_ccla"
   ]
 }

--- a/templates/default/.env.production.erb
+++ b/templates/default/.env.production.erb
@@ -56,4 +56,6 @@ ICLA_VERSION=99999-2621/LEGAL14767024.1
 <% @app['feature_flags'].each do |feature_flag| %>
 <%= feature_flag.upcase %>=true
 <% end %>
+<% if @app['features'] %>
+FEATURES=<%= @app['features'].join(',') %>
 <% end %>

--- a/test/integration/default/serverspec/app_spec.rb
+++ b/test/integration/default/serverspec/app_spec.rb
@@ -30,6 +30,6 @@ describe 'supermarket' do
 
   it 'writes feature flags to .env.production from the apps databag' do
     cmd = command 'cat /srv/supermarket/shared/.env.production'
-    expect(cmd.stdout).to match 'TOOLS_ENABLED=true'
+    expect(cmd.stdout).to match 'FEATURES=tools,join_ccla'
   end
 end


### PR DESCRIPTION
:fork_and_knife: To more easily accommodate using rollout in Supermarket instead of having an ENV variable for each feature just use one comma separated FEATURES ENV.

_Leaving in the current feature flags until we have rollout rolled out so we don't have the chicken or the egg problem. So we should probably release this cookbook, merge in https://github.com/opscode/supermarket/pull/718, then remove the other feature flags from `.env.production`._

To accompany https://github.com/opscode/supermarket/pull/718.
