### PR TITLE
update bundler to 1.7.2

### DIFF
--- a/recipes/_ruby.rb
+++ b/recipes/_ruby.rb
@@ -55,4 +55,6 @@ package 'libsqlite3-dev'
 # when postgresql isn't running on the same node.
 package 'libpq-dev'
 
-gem_package 'bundler'
+gem_package 'bundler' do
+  version '>= 1.7.2'
+end


### PR DESCRIPTION
:fork_and_knife: 

Currently supermarket-staging is running bundler 1.5.2.  https://github.com/opscode/supermarket/pull/792 introduced code using the `git_source` method, which wasn't added to bundler until 1.6.0, so CCR on supermarket-staging currently fails.

This fixes that by updating bundler to the latest stable version.
