### PR TITLE
run bundle exec as the supermarket user

### DIFF
--- a/templates/default/unicorn.sv.erb
+++ b/templates/default/unicorn.sv.erb
@@ -46,7 +46,7 @@ function start {
     echo 'Starting new Unicorn instance'
     cd <%= node['supermarket']['home'] %>/current
     export WEB_CONCURRENCY=<%= node['supermarket']['web_concurrency'] %>
-    bundle exec unicorn -E production -c config/unicorn/production.rb -D
+    exec chpst -u supermarket -P bundle exec unicorn -E production -c config/unicorn/production.rb -D
     sleep 3
     CUR_PID=$(cat $CUR_PID_FILE)
   fi


### PR DESCRIPTION
I'm not entirely certain this is the right thing to do, but allow me to explain my rationale for this change.

Earlier today, the unicorn died on the supermarket-staging node and when I tried to restart it, this message showed up in the logs:

![](https://dl.dropboxusercontent.com/s/uca5y49a1i2oimm/2014-09-08%20at%201.03%20PM.png?dl=0)

which prevented unicorn from starting. Since PG uses peer auth, it seems to make sense that unicorn would need to be run as the supermarket user, since that's also the db user. Also, I think that without this change, unicorn runs as root, which seems bad.

The part I can't explain is how this worked last week and not today.
