### PR TITLE
This commit update ruby from 2.0.0 to 2.1.3

### DIFF
--- a/recipes/_ruby.rb
+++ b/recipes/_ruby.rb
@@ -22,7 +22,7 @@
 #   action :nothing
 # end
 
-# file "/etc/profile.d/chef_ruby.sh" do 
+# file "/etc/profile.d/chef_ruby.sh" do
 #  content <<-EOD
 #    export PATH=/opt/chef/embedded/bin/:$PATH
 #  EOD
@@ -30,14 +30,14 @@
 # end
 
 node.default[:chruby_install][:default_ruby] = true
-node.default[:rubies][:list] = [ 'ruby 2.0.0-p576' ]
+node.default[:rubies][:list] = [ 'ruby 2.1.3' ]
 node.default[:rubies][:bundler][:install] = false
 
 include_recipe 'rubies'
 
 %w{erb gem irb rake rdoc ri ruby testrb bundle bundler }.each do |rb|
   link "/usr/bin/#{rb}" do
-    to "/opt/rubies/ruby-2.0.0-p576/bin/#{rb}"
+    to "/opt/rubies/ruby-2.1.3/bin/#{rb}"
   end
 end
 
@@ -46,12 +46,12 @@ node['supermarket']['gem']['dep_packages'].each do |pkg|
 end
 
 gem_package 'bundler' do
-  gem_binary("/opt/rubies/ruby-2.0.0-p576/bin/gem")
+  gem_binary("/opt/rubies/ruby-2.1.3/bin/gem")
   version '>= 1.7.3'
 end
 
 %w{ bundle bundler }.each do |rb|
   link "/usr/bin/#{rb}" do
-    to "/opt/rubies/ruby-2.0.0-p576/bin/#{rb}"
+    to "/opt/rubies/ruby-2.1.3/bin/#{rb}"
   end
 end


### PR DESCRIPTION
The opscode/supermarket project was updated to 2.1.3. When the
application recipe attempts to bundle install the gems from the
supermarket application, the command fails stating that the current ruby
installed is ruby 2.0.0 instead of the Gemfile requirement of 2.1.3.
