### PR TITLE
Remove comments from _ruby recipe.

### DIFF
--- a/recipes/_ruby.rb
+++ b/recipes/_ruby.rb
@@ -17,18 +17,6 @@
 # limitations under the License.
 #
 
-# execute "source_etc_profile" do
-#   command "source /etc/profile"
-#   action :nothing
-# end
-
-# file "/etc/profile.d/chef_ruby.sh" do
-#  content <<-EOD
-#    export PATH=/opt/chef/embedded/bin/:$PATH
-#  EOD
-#  notifies :run, "execute[source_etc_profile]"
-# end
-
 node.default[:chruby_install][:default_ruby] = true
 node.default[:rubies][:list] = [ 'ruby 2.1.3' ]
 node.default[:rubies][:bundler][:install] = false


### PR DESCRIPTION
These comments are probably unnecessary and may have been used for
chruby prior to using the
https://github.com/ichilton/chef_chruby_install cookbook. Since this
cookbook is used, both of these lines are handled by the
chef_chruby_install default recipe.
